### PR TITLE
feat: Add navigation links to hero section buttons

### DIFF
--- a/apps/web/src/features/home/sections/hero-section.tsx
+++ b/apps/web/src/features/home/sections/hero-section.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import { Button } from "../../../shared/components/ui/button";
 import HeroSearchDemo from "../components/hero-search-demo";
 
@@ -18,8 +19,12 @@ export default function HeroSection() {
             </p>
           </div>
           <div className="flex flex-row items-center gap-4">
-            <Button size="lg">Sign Up gratis</Button>
-            <Button variant="outline">Login</Button>
+            <Link to="/register">
+              <Button size="lg">Sign Up gratis</Button>
+            </Link>
+            <Link to="/login">
+              <Button variant="outline">Login</Button>
+            </Link>
           </div>
         </div>
         <div>


### PR DESCRIPTION
## Summary
- Wrapped Sign Up and Login buttons in the hero section with Link components from @tanstack/react-router
- Sign Up button now navigates to `/register` route
- Login button now navigates to `/login` route

## Changes
- Added `Link` import from `@tanstack/react-router` in `apps/web/src/features/home/sections/hero-section.tsx`
- Wrapped both buttons in Link components with appropriate routing paths

## Test plan
- [ ] Verify Sign Up button navigates to registration page
- [ ] Verify Login button navigates to login page
- [ ] Check that button styling remains unchanged
- [ ] Test navigation behavior on both desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)