### PR TITLE
Fix: Add text truncation for long file and folder names

### DIFF
--- a/apps/web/src/features/dashboard/components/recent-update-item.tsx
+++ b/apps/web/src/features/dashboard/components/recent-update-item.tsx
@@ -19,7 +19,7 @@ export function RecentUpdateItem({
       <FileTextIcon className="size-5 text-primary" />
       <div className="flex-1 space-y-1">
         <div className="flex items-center gap-2">
-          <h3 className="font-semibold text-base">{title}</h3>
+          <h3 className="truncate font-semibold text-base">{title}</h3>
           <Badge variant="secondary">{type}</Badge>
         </div>
         <p className="text-muted-foreground text-sm">{description}</p>

--- a/apps/web/src/features/knowledge-sources/components/file-card.tsx
+++ b/apps/web/src/features/knowledge-sources/components/file-card.tsx
@@ -64,7 +64,7 @@ export function FileCard({ file }: FileCardProps) {
         <div className="mb-4">
           <Icon className="size-12 text-green-600" />
         </div>
-        <CardTitle className="text-xl">{file.name}</CardTitle>
+        <CardTitle className="truncate text-xl">{file.name}</CardTitle>
         <CardDescription>
           {size} -{" "}
           {file.createdAt.toLocaleDateString("id-ID", {

--- a/apps/web/src/features/knowledge-sources/components/folder-card.tsx
+++ b/apps/web/src/features/knowledge-sources/components/folder-card.tsx
@@ -49,7 +49,7 @@ export function FolderCard({ folder }: FolderCardProps) {
         <div className="mb-4">
           <FolderOpen className="size-12 text-green-600" />
         </div>
-        <CardTitle className="text-xl">{folder.name}</CardTitle>
+        <CardTitle className="truncate text-xl">{folder.name}</CardTitle>
         <CardDescription>Dibuat oleh {folder.user.role}</CardDescription>
       </CardHeader>
       <CardContent>

--- a/apps/web/src/features/knowledge-sources/components/upload-file-dialog.tsx
+++ b/apps/web/src/features/knowledge-sources/components/upload-file-dialog.tsx
@@ -71,7 +71,10 @@ export function UploadFileDialog({
         {
           loading: "Mengunggah file...",
           success: "File berhasil diunggah",
-          error: "Gagal mengunggah file. Silakan coba lagi.",
+          error: (e) => ({
+            message: "Gagal mengunggah file. Silakan coba lagi.",
+            description: e.message || "",
+          }),
         }
       );
       setIsOpen(false);
@@ -115,8 +118,10 @@ export function UploadFileDialog({
                         <FieldLabel htmlFor={field.name}>File</FieldLabel>
                         {selectedFile ? (
                           <div className="flex items-center justify-between gap-4 rounded-md border p-2">
-                            <div>
-                              <p className="font-medium">{selectedFile.name}</p>
+                            <div className="min-w-0 flex-1">
+                              <p className="truncate font-medium">
+                                {selectedFile.name}
+                              </p>
                               <p className="text-muted-foreground text-sm">
                                 {formatFileSize(selectedFile.size)}
                               </p>


### PR DESCRIPTION
## Summary
- Fixed text overflow issues in file and folder name displays across 4 components
- Added `truncate` CSS class to prevent layout breaking with long names
- Improved error handling in UploadFileDialog to show detailed error messages

## Changes

### 1. FolderCard Component
**File**: `apps/web/src/features/knowledge-sources/components/folder-card.tsx:52`
- Added `truncate` class to `CardTitle` to prevent long folder names from overflowing

### 2. FileCard Component  
**File**: `apps/web/src/features/knowledge-sources/components/file-card.tsx:67`
- Added `truncate` class to `CardTitle` to prevent long file names from overflowing

### 3. UploadFileDialog Component
**File**: `apps/web/src/features/knowledge-sources/components/upload-file-dialog.tsx`
- Added `min-w-0 flex-1` to parent container and `truncate` to filename paragraph (lines 118-121)
- Enhanced error handling to display detailed error descriptions (lines 74-77)

### 4. RecentUpdateItem Component
**File**: `apps/web/src/features/dashboard/components/recent-update-item.tsx:22`
- Added `truncate` class to title heading to prevent long update titles from overflowing

## Test Plan
- [ ] Test FolderCard with short folder names (< 20 chars)
- [ ] Test FolderCard with very long folder names (> 100 chars)
- [ ] Test FileCard with short file names
- [ ] Test FileCard with very long file names with extensions
- [ ] Test UploadFileDialog file preview with long filenames
- [ ] Test RecentUpdateItem with long titles
- [ ] Verify ellipsis (...) appears correctly when text is truncated
- [ ] Verify layout remains intact on different screen sizes
- [ ] Verify error messages display with descriptions in upload dialog

## Related Issue
Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>